### PR TITLE
WIP: Brackets newline

### DIFF
--- a/editor/RubyScanner.cpp
+++ b/editor/RubyScanner.cpp
@@ -125,9 +125,9 @@ Token Scanner::read()
     QChar saved;
     parseState(state, saved);
     switch (state) {
-    case State_String:
-    case State_Regexp:
-    case State_Symbols:
+    case State::String:
+    case State::Regexp:
+    case State::Symbols:
         return readStringLiteral(saved, state);
     default:
         return onDefaultState();
@@ -201,7 +201,7 @@ Token Scanner::onDefaultState()
     if (first.isDigit()) {
         token = readFloatNumber();
     } else if (first == '\'' || first == '\"' || first == '`') {
-        token = readStringLiteral(first, State_String);
+        token = readStringLiteral(first, State::String);
     } else if (m_methodPattern.match(m_tokenSequence).hasMatch()) {
         token = readMethodDefinition();
     } else if (first == '$' && (m_src.peek() == '`' || m_src.peek() == '\'')) {
@@ -252,9 +252,9 @@ Token Scanner::onDefaultState()
 
 static Token::Kind tokenKindFor(QChar ch, Scanner::State state)
 {
-    if (state == Scanner::State_Regexp)
+    if (state == Scanner::State::Regexp)
         return Token::Regexp;
-    else if (state == Scanner::State_Symbols)
+    else if (state == Scanner::State::Symbols)
         return Token::Symbol;
 
     switch(ch.toLatin1()) {
@@ -334,7 +334,7 @@ Token Scanner::readStringLiteral(QChar quoteChar, Scanner::State state)
 
     if (ch == quoteChar) {
         m_src.move();
-        if (state == State_Regexp)
+        if (state == State::Regexp)
             consumeRegexpModifiers();
         clearState();
     }
@@ -608,12 +608,12 @@ Token Scanner::readPercentageNotation()
     if (ch.isSpace() || ch.isDigit())
         return Token(Token::Operator, m_src.anchor(), m_src.length());
 
-    State state = State_String;
+    State state = State::String;
     if (ch.isLetter()) {
         if (ch == 'r')
-            state = State_Regexp;
+            state = State::Regexp;
         if (ch == 'i')
-            state = State_Symbols;
+            state = State::Symbols;
         m_src.move();
     }
     QChar delimiter = translateDelimiter(m_src.peek());
@@ -653,7 +653,7 @@ void Scanner::clearState()
 
 void Scanner::saveState(State state, QChar savedData)
 {
-    m_state = (state << 16) | static_cast<int>(savedData.unicode());
+    m_state = (int(state) << 16) | static_cast<int>(savedData.unicode());
 }
 
 void Scanner::parseState(State &state, QChar &savedData) const

--- a/editor/RubyScanner.cpp
+++ b/editor/RubyScanner.cpp
@@ -104,6 +104,7 @@ Scanner::StateUnion::StateUnion(QChar delim, State st)
 {
     delimiter = delim.unicode();
     state = st;
+    bracketCount = 0;
 }
 
 Scanner::Scanner(const QString *text)
@@ -299,7 +300,6 @@ Token Scanner::readStringLiteral(StateUnion state)
 
     QChar startQuoteChar = translateDelimiter(state.delimiter);
     bool quoteCharHasPair = delimiterHasPair(state.delimiter);
-    int bracketCount = 0;
 
     forever {
         ch = m_src.peek();
@@ -308,17 +308,17 @@ Token Scanner::readStringLiteral(StateUnion state)
             break;
         }
 
-        if (ch == state.delimiter && bracketCount == 0)
+        if (ch == state.delimiter && state.bracketCount == 0)
             break;
 
         // handles %r{{}}
         if (quoteCharHasPair) {
             if (ch == startQuoteChar) {
-                bracketCount++;
+                state.bracketCount++;
                 m_src.move();
                 continue;
             } else if (ch == state.delimiter) {
-                bracketCount--;
+                state.bracketCount--;
                 m_src.move();
                 continue;
             }

--- a/editor/RubyScanner.h
+++ b/editor/RubyScanner.h
@@ -109,6 +109,7 @@ private:
         struct {
             unsigned short delimiter;
             State state;
+            unsigned char bracketCount;
         };
 
         StateUnion();

--- a/editor/RubyScanner.h
+++ b/editor/RubyScanner.h
@@ -104,9 +104,20 @@ public:
     // current line has a else, elsif, rescue or ensure.
     bool didBlockInterrupt();
 private:
+    union StateUnion {
+        int all;
+        struct {
+            unsigned short delimiter;
+            State state;
+        };
+
+        StateUnion();
+        StateUnion(QChar delim, State st);
+    };
+
     Token onDefaultState();
 
-    Token readStringLiteral(QChar quoteChar, State stateRestored);
+    Token readStringLiteral(StateUnion state);
     Token readInStringToken();
     Token readRegexp();
     Token readIdentifier();
@@ -123,11 +134,11 @@ private:
     void consumeRegexpModifiers();
 
     void clearState();
-    void saveState(State state, QChar savedData);
-    void parseState(State &state, QChar &savedData) const;
+    void saveState(StateUnion state);
+    void parseState(StateUnion &state) const;
 
     SourceCodeStream m_src;
-    int m_state = 0;
+    StateUnion m_state;
     bool m_hasContextRecognition = false;
 
     QString m_tokenSequence;

--- a/editor/RubyScanner.h
+++ b/editor/RubyScanner.h
@@ -79,11 +79,11 @@ class Scanner
     Q_DISABLE_COPY(Scanner)
 
 public:
-    enum State {
-        State_Default,
-        State_String,
-        State_Regexp,
-        State_Symbols
+    enum class State : char {
+        Default,
+        String,
+        Regexp,
+        Symbols
     };
 
     Scanner(const QString *text);

--- a/editor/ScannerTest.cpp
+++ b/editor/ScannerTest.cpp
@@ -175,6 +175,7 @@ void Plugin::test_ifs()
 void Plugin::test_scanner()
 {
     QFETCH(TestData, td);
+    QEXPECT_FAIL("Brackets + newline", "Not working", Continue);
     QCOMPARE(tokenize(td.input), td.tokens);
 }
 
@@ -258,6 +259,7 @@ void Plugin::test_scanner_data()
     QTest::newRow("Brackets 3") << TestData("%q[[]]", { Token::String });
     QTest::newRow("Brackets 4") << TestData("%w(())", { Token::String });
     QTest::newRow("Brackets 5") << TestData("%q!\\!!", { Token::String });
+    QTest::newRow("Brackets + newline") << TestData("%q{{\n}\n}", { Token::String, Token::String });
     QTest::newRow("keyword symbols 1")
             << TestData("if: :foo", { Token::SymbolHashKey, Token::Whitespace, Token::Symbol });
     QTest::newRow("keyword symbols 2")


### PR DESCRIPTION
Hi,

This still doesn't work, but I can't find what I missed. Can you please help with it? There's a really simple test-case for the bug:

```ruby
%q{{
}
} # This bracket is not highlighted as a string
```

All the 3 patches up to and including "Scanner: Convert state to a union/struct" should be fine, and all the tests pass (you can do a partial merge if you like them).

The additional test fails for both versions.