### PR TITLE
Rubocop: Fix crash when closing document while parsing

### DIFF
--- a/editor/RubyRubocopHighlighter.cpp
+++ b/editor/RubyRubocopHighlighter.cpp
@@ -114,7 +114,8 @@ void RubocopHighlighter::initRubocopProcess()
 
 void RubocopHighlighter::finishRuboCopHighlight()
 {
-    if (m_startRevision != m_document->document()->revision()) {
+    QTextDocument *doc = m_document ? m_document->document() : nullptr;
+    if (!doc || m_startRevision != doc->revision()) {
         m_busy = false;
         return;
     }

--- a/editor/RubyRubocopHighlighter.h
+++ b/editor/RubyRubocopHighlighter.h
@@ -9,6 +9,7 @@
 #include <QFuture>
 #include <QFutureWatcher>
 #include <QElapsedTimer>
+#include <QPointer>
 #include <QTemporaryFile>
 
 #include <functional>
@@ -64,7 +65,7 @@ private:
     QString m_outputBuffer;
 
     int m_startRevision = 0;
-    TextEditor::TextDocument *m_document = nullptr;
+    QPointer<TextEditor::TextDocument> m_document;
     QHash<int, QTextCharFormat> m_extraFormats;
 
 


### PR DESCRIPTION
Was supposed to be in 4.6.0, but I created the PR for master by mistake.